### PR TITLE
Added maximum call depth to protect against crashes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# Lox interpreter
-This is a C++ implementation of the Lox programming language which is described in the book [Crafting Interpreters](http://www.craftinginterpreters.com/) by [Bob Nystrom](https://github.com/munificent). I have written this interpreter as an exercise while following the book (to learn to write interpreters), so it's probably not production-quality code. All features (and some extra ones suggested in the book) are implemented. Compilation requires a C++11-compliant compiler.
+# Fork of https://github.com/ThorNielsen/loxint
+
+I added a maximum call depth to protect against stack overflows and resulting crashes.  
+A test script can be found at `scripts/stackoverflow.lox`.

--- a/scripts/stackoverflow.lox
+++ b/scripts/stackoverflow.lox
@@ -1,0 +1,8 @@
+// A (very) bad implementation of the factorial operation.
+fun fact(n) {
+	if (n==1) return 1;
+	else return n * fact(n);
+}
+
+// Will cause a stack overflow.
+fact(5);

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -26,6 +26,10 @@ ExprRetType Interpreter::visitBinaryExpr(BinaryExpr& bin)
 
 ExprRetType Interpreter::visitCallExpr(CallExpr& ce)
 {
+    m_calldepth += 1;
+    if (m_calldepth >= MAX_CALL_DEPTH) {
+        throw LoxError(error(ce.paren.line, "Maximum call depth reached."));
+    }
     auto callee = ce.callee->accept(*this);
     std::vector<LoxObject> args;
     for (auto& arg : ce.args)

--- a/src/interpreter.hpp
+++ b/src/interpreter.hpp
@@ -1,6 +1,9 @@
 #ifndef INTERPRETER_HPP_INCLUDED
 #define INTERPRETER_HPP_INCLUDED
 
+#define MAX_CALL_DEPTH 1024
+
+#include "error.hpp"
 #include "callable.hpp"
 #include "environment.hpp"
 #include "expr.hpp"
@@ -335,7 +338,7 @@ public:
     }
 
 private:
-
+    int m_calldepth = 0;
 
     LoxObject& getVariable(Token name, Expr* expr)
     {


### PR DESCRIPTION
Infinite recursion is now stopped after a set limit defined in `interpreter.hpp` by `MAX_CALL_DEPTH`.
Each call is counted and upon reaching the limit, the program aborts.